### PR TITLE
Improve splitAtBoundary performance

### DIFF
--- a/Network/Multipart.hs
+++ b/Network/Multipart.hs
@@ -33,7 +33,6 @@ module Network.Multipart
     ) where
 
 import Control.Monad
-import Data.Int (Int64)
 import Data.List (intersperse)
 import Data.Maybe
 import System.IO (Handle)
@@ -67,14 +66,11 @@ hGetMultipartBody :: String -- ^ Boundary
                   -> IO MultiPart
 hGetMultipartBody b = liftM (parseMultipartBody b) . BS.hGetContents
 
-
-
 parseBodyPart :: ByteString -> Maybe BodyPart
-parseBodyPart s =
-    do
-    let (hdr,bdy) = splitAtEmptyLine s
-    hs <- parseM pHeaders "<input>" (BS.unpack hdr)
-    return $ BodyPart hs bdy
+parseBodyPart s = do
+  let (hdr,bdy) = splitAtEmptyLine s
+  hs <- parseM pHeaders "<input>" (BS.unpack hdr)
+  return $ BodyPart hs bdy
 
 showMultipartBody :: String -> MultiPart -> ByteString
 showMultipartBody b (MultiPart bs) =
@@ -85,7 +81,6 @@ showMultipartBody b (MultiPart bs) =
 showBodyPart :: BodyPart -> ByteString
 showBodyPart (BodyPart hs c) =
     unlinesCRLF $ [BS.pack (n++": "++v) | (HeaderName n,v) <- hs] ++ [BS.empty,c]
-
 
 --
 -- * Splitting into multipart parts.
@@ -107,9 +102,9 @@ splitParts b = spl . dropPreamble b
 dropPreamble :: ByteString -- ^ The boundary, without the initial dashes
              -> ByteString
              -> ByteString
-dropPreamble b s | BS.null s = BS.empty
-                 | isBoundary b s = dropLine s
-                 | otherwise = dropPreamble b (dropLine s)
+dropPreamble b s = case splitAtBoundary b s of
+  Nothing -> BS.empty
+  Just (_,_,v) -> v
 
 -- | Split a string at the first boundary line.
 splitAtBoundary :: ByteString -- ^ The boundary, without the initial dashes
@@ -131,25 +126,12 @@ splitAtBoundary b s =
                Just t'' -> t''
          in  Just (before, bcrlf, after)
 
-
--- | Check whether a string starts with two dashes followed by
---   the given boundary string.
-isBoundary :: ByteString -- ^ The boundary, without the initial dashes
-           -> ByteString
-           -> Bool
-isBoundary b s = startsWithDashes s && b `BS.isPrefixOf` BS.drop 2 s
-
 -- | Check whether a string for which 'isBoundary' returns true
 --   has two dashes after the boudary string.
 isClose :: ByteString -- ^ The boundary, without the initial dashes
         -> ByteString
         -> Bool
-isClose b s = startsWithDashes (BS.drop (2+BS.length b) s)
-
--- | Checks whether a string starts with two dashes.
-startsWithDashes :: ByteString -> Bool
-startsWithDashes s = BS.pack "--" `BS.isPrefixOf` s
-
+isClose b s = BS.isPrefixOf (BS.append "--" (BS.append b "--")) s
 
 --
 -- * RFC 2046 CRLF
@@ -161,63 +143,15 @@ crlf = BS.pack "\r\n"
 unlinesCRLF :: [ByteString] -> ByteString
 unlinesCRLF = BS.concat . intersperse crlf
 
--- | Drop everything up to and including the first CRLF.
-dropLine :: ByteString -> ByteString
-dropLine s = snd (splitAtCRLF s)
-
 -- | Split a string at the first empty line. The CRLF (if any) before the
 --   empty line is included in the first result. The CRLF after the
 --   empty line is not included in the result.
 --   If there is no empty line, the entire input is returned
 --   as the first result.
 splitAtEmptyLine :: ByteString -> (ByteString, ByteString)
-splitAtEmptyLine s | startsWithCRLF s = (BS.empty, dropCRLF s)
-                   | otherwise = spl 0
-  where
-  spl i = case findCRLF (BS.drop i s) of
-              Nothing -> (s, BS.empty)
-              Just (j,l) | startsWithCRLF s2 -> (s1, dropCRLF s2)
-                         | otherwise -> spl (i+j+l)
-                where (s1,s2) = BS.splitAt (i+j+l) s
-
--- | Split a string at the first CRLF. The CRLF is not included
---   in any of the returned strings.
---   If there is no CRLF, the entire input is returned
---   as the first string.
-splitAtCRLF :: ByteString -- ^ String to split.
-            -> (ByteString,ByteString)
-splitAtCRLF s = case findCRLF s of
-                  Nothing -> (s,BS.empty)
-                  Just (i,l) -> (s1, BS.drop l s2)
-                      where (s1,s2) = BS.splitAt i s
-
--- | Get the index and length of the first CRLF, if any.
-findCRLF :: ByteString -- ^ String to split.
-         -> Maybe (Int64,Int64)
-findCRLF s =
-    case findCRorLF s of
-              Nothing -> Nothing
-              Just j | BS.null (BS.drop (j+1) s) -> Just (j,1)
-              Just j -> case (BS.index s j, BS.index s (j+1)) of
-                           ('\n','\r') -> Just (j,2)
-                           ('\r','\n') -> Just (j,2)
-                           _           -> Just (j,1)
-
-findCRorLF :: ByteString -> Maybe Int64
-findCRorLF s = BS.findIndex (\c -> c == '\n' || c == '\r') s
-
-startsWithCRLF :: ByteString -> Bool
-startsWithCRLF s = not (BS.null s) && (c == '\n' || c == '\r')
-  where c = BS.index s 0
-
--- | Drop an initial CRLF, if any. If the string is empty,
---   nothing is done. If the string does not start with CRLF,
---   the first character is dropped.
-dropCRLF :: ByteString -> ByteString
-dropCRLF s | BS.null s = BS.empty
-           | BS.null (BS.drop 1 s) = BS.empty
-           | c0 == '\n' && c1 == '\r' = BS.drop 2 s
-           | c0 == '\r' && c1 == '\n' = BS.drop 2 s
-           | otherwise = BS.drop 1 s
-  where c0 = BS.index s 0
-        c1 = BS.index s 1
+splitAtEmptyLine s =
+  let blank = "\r\n\r\n"
+      (before, after) = breakOn (BS.toStrict blank) s
+  in case BS.stripPrefix blank after of
+       Nothing -> (before, after)
+       Just after' -> (BS.append before "\r\n", after')

--- a/multipart.cabal
+++ b/multipart.cabal
@@ -29,6 +29,6 @@ library
     Network.Multipart.Header
   build-depends:
       base >= 3 && < 5
-    , bytestring
+    , bytestring >= 0.10.8.0 && < 0.11
     , parsec >= 2.0
     , stringsearch

--- a/multipart.cabal
+++ b/multipart.cabal
@@ -31,3 +31,4 @@ library
       base >= 3 && < 5
     , bytestring
     , parsec >= 2.0
+    , stringsearch


### PR DESCRIPTION
I replaced the custom substring function with the one from `stringsearch`, which yielded a nice performance bump when using `parseMultipartBody`.

Please let me know if you'd like any changes made before upstreaming.

When parsing an email with 6MB of attachments, I recorded the following performance:
### Before this commit:
```
        Thu Aug  2 08:23 2018 Time and Allocation Profiling Report  (Final)

           main +RTS -p -RTS ./attachments.mbox

        total time  =       33.56 secs   (33563 ticks @ 1000 us, 1 processor)
        total alloc = 444,337,760 bytes  (excludes profiling overheads)

COST CENTRE            MODULE                             SRC                                                   %time %alloc

splitAtBoundary.spl.s2 Network.Multipart                  src/Network/Multipart.hs:132:19-40                     49.7    0.0
splitAtBoundary.spl    Network.Multipart                  src/Network/Multipart.hs:(126,3)-(133,41)              49.3    0.9
lines8                 Text.PortableLines.ByteString.Lazy Text/PortableLines/ByteString/Lazy.hs:(19,1)-(21,48)    0.4   33.3
b64strip               Email.Parse                        src/Email/Parse.hs:252:1-80                             0.3   35.3
findCRorLF             Network.Multipart                  src/Network/Multipart.hs:207:1-60                       0.1    2.4
breakDelim             Data.List.Split.Internals          src/Data/List/Split/Internals.hs:(151,1)-(156,36)       0.0    2.9
mboxMessages.f.\       Email.Parse.MBox                   src/Email/Parse/MBox.hs:33:17-73                        0.0    4.5
satisfy                Text.Parsec.Char                   Text/Parsec/Char.hs:(140,1)-(142,71)                    0.0    1.7
findCRLF               Network.Multipart                  src/Network/Multipart.hs:(197,1)-(204,52)               0.0    2.6
decodeUtf8With         Data.Text.Encoding                 Data/Text/Encoding.hs:(132,1)-(155,71)                  0.0    2.9
encodeUtf8             Data.Text.Encoding                 Data/Text/Encoding.hs:(373,1)-(388,37)                  0.0    5.7
openMbox               Email.Parse.MBox                   src/Email/Parse/MBox.hs:21:1-46                         0.0    1.5
splitAtBoundary.spl.s1 Network.Multipart                  src/Network/Multipart.hs:131:19-38                      0.0    3.3
```

### After this commit:

```
        Thu Aug  2 08:24 2018 Time and Allocation Profiling Report  (Final)

           main +RTS -p -RTS ./attachments.mbox

        total time  =        0.25 secs   (250 ticks @ 1000 us, 1 processor)
        total alloc = 564,201,000 bytes  (excludes profiling overheads)

COST CENTRE           MODULE                             SRC                                                   %time %alloc

b64strip              Email.Parse                        src/Email/Parse.hs:252:1-80                            37.2   27.8
lines8                Text.PortableLines.ByteString.Lazy Text/PortableLines/ByteString/Lazy.hs:(19,1)-(21,48)   31.6   26.2
splitAtBoundary.(...) Network.Multipart                  src/Network/Multipart.hs:125:7-49                      18.0   28.5
breakDelim            Data.List.Split.Internals          src/Data/List/Split/Internals.hs:(151,1)-(156,36)       2.4    2.3
satisfy               Text.Parsec.Char                   Text/Parsec/Char.hs:(140,1)-(142,71)                    2.0    1.3
mboxMessages.f.\      Email.Parse.MBox                   src/Email/Parse/MBox.hs:33:17-73                        1.6    3.6
main.\.\.\            Main                               src-bin/main.hs:20:20-113                               1.2    0.0
openMbox              Email.Parse.MBox                   src/Email/Parse/MBox.hs:21:1-46                         1.2    1.2
decodeUtf8With        Data.Text.Encoding                 Data/Text/Encoding.hs:(132,1)-(155,71)                  0.8    2.3
encodeUtf8            Data.Text.Encoding                 Data/Text/Encoding.hs:(373,1)-(388,37)                  0.4    4.5
```